### PR TITLE
Add dependency on ghc-prim for ghc-7.4.2.

### DIFF
--- a/distributed-process-tests.cabal
+++ b/distributed-process-tests.cabal
@@ -45,6 +45,8 @@ library
                      RankNTypes,
                      RecordWildCards,
                      ScopedTypeVariables
+  if impl(ghc <= 7.4.2)
+    Build-Depends:   ghc-prim == 0.2.0.0
 
 Test-Suite TestCH
   Type:              exitcode-stdio-1.0


### PR DESCRIPTION
d-p-tests requires GHC.Generics which is part of ghc-prim in the packages shipped with ghc-7.4.2.
