### PR TITLE
Bump upper bound of network-transport to < 0.5.

### DIFF
--- a/distributed-process-tests.cabal
+++ b/distributed-process-tests.cabal
@@ -27,7 +27,7 @@ library
                      distributed-process,
                      distributed-static,
                      HUnit >= 1.2 && < 1.3,
-                     network-transport >= 0.3 && < 0.4,
+                     network-transport >= 0.3 && < 0.5,
                      network >= 2.3 && < 2.5,
                      random >= 1.0 && < 1.1,
                      rematch >= 0.1.2.1,
@@ -53,8 +53,8 @@ Test-Suite TestCH
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
                      network >= 2.3 && < 2.5,
-                     network-transport >= 0.3 && < 0.4,
-                     network-transport-tcp >= 0.3 && < 0.4,
+                     network-transport >= 0.3 && < 0.5,
+                     network-transport-tcp >= 0.3 && < 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
   ghc-options:       -Wall -threaded -debug -eventlog -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
@@ -67,8 +67,8 @@ Test-Suite TestClosure
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
                      network >= 2.3 && < 2.5,
-                     network-transport >= 0.3 && < 0.4,
-                     network-transport-tcp >= 0.3 && < 0.4,
+                     network-transport >= 0.3 && < 0.5,
+                     network-transport-tcp >= 0.3 && < 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
@@ -81,8 +81,8 @@ Test-Suite TestStats
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
                      network >= 2.3 && < 2.5,
-                     network-transport >= 0.3 && < 0.4,
-                     network-transport-tcp >= 0.3 && < 0.4,
+                     network-transport >= 0.3 && < 0.5,
+                     network-transport-tcp >= 0.3 && < 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
   ghc-options:       -Wall -debug -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
@@ -96,8 +96,8 @@ Test-Suite TestMx
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
                      network >= 2.3 && < 2.5,
-                     network-transport >= 0.3 && < 0.4,
-                     network-transport-tcp >= 0.3 && < 0.4,
+                     network-transport >= 0.3 && < 0.5,
+                     network-transport-tcp >= 0.3 && < 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
   ghc-options:       -Wall -debug -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind
@@ -110,8 +110,8 @@ Test-Suite TestTracing
   Build-Depends:     base >= 4.4 && < 5,
                      distributed-process-tests,
                      network >= 2.3 && < 2.5,
-                     network-transport >= 0.3 && < 0.4,
-                     network-transport-tcp >= 0.3 && < 0.4,
+                     network-transport >= 0.3 && < 0.5,
+                     network-transport-tcp >= 0.3 && < 0.5,
                      test-framework >= 0.6 && < 0.9
   Extensions:        CPP
   ghc-options:       -Wall -debug -eventlog -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind


### PR DESCRIPTION
This is needed to build distributed-process-tests with the latest released version of network-transport on hackage.
