### PR TITLE
Remove threadDelay in monitoring tests.

### DIFF
--- a/src/Control/Distributed/Process/Tests/CH.hs
+++ b/src/Control/Distributed/Process/Tests/CH.hs
@@ -199,7 +199,7 @@ testMonitorUnreachable TestTransport{..} mOrL un = do
 
   forkIO $ do
     localNode <- newLocalNode testTransport initRemoteTable
-    addr <- forkProcess localNode . liftIO $ threadDelay 1000000
+    addr <- forkProcess localNode expect
     closeLocalNode localNode
     putMVar deadProcess addr
 


### PR DESCRIPTION
Improve tests by removing more threadDelays,
so test will not depend on time.