### PR TITLE
Tests for unsafeNSendRemote and unsafeUSend

### DIFF
--- a/src/Control/Distributed/Process/Tests/CH.hs
+++ b/src/Control/Distributed/Process/Tests/CH.hs
@@ -1385,6 +1385,26 @@ testUnsafeSend TestTransport{..} = do
 
   takeMVar clientDone
 
+testUnsafeUSend :: TestTransport -> Assertion
+testUnsafeUSend TestTransport{..} = do
+  serverAddr <- newEmptyMVar
+  clientDone <- newEmptyMVar
+
+  localNode <- newLocalNode testTransport initRemoteTable
+  void $ forkProcess localNode $ do
+    self <- getSelfPid
+    liftIO $ putMVar serverAddr self
+    clientAddr <- expect
+    unsafeUSend clientAddr ()
+
+  void $ forkProcess localNode $ do
+    serverPid <- liftIO $ takeMVar serverAddr
+    getSelfPid >>= unsafeUSend serverPid
+    () <- expect
+    liftIO $ putMVar clientDone ()
+
+  takeMVar clientDone
+
 testUnsafeNSend :: TestTransport -> Assertion
 testUnsafeNSend TestTransport{..} = do
   clientDone <- newEmptyMVar
@@ -1541,6 +1561,7 @@ tests testtrans = return [
       , testCase "TextCallLocal"       (testCallLocal           testtrans)
       -- Unsafe Primitives
       , testCase "TestUnsafeSend"      (testUnsafeSend          testtrans)
+      , testCase "TestUnsafeUSend"     (testUnsafeUSend         testtrans)
       , testCase "TestUnsafeNSend"     (testUnsafeNSend         testtrans)
       , testCase "TestUnsafeSendChan"  (testUnsafeSendChan      testtrans)
       -- usend

--- a/src/Control/Distributed/Process/Tests/CH.hs
+++ b/src/Control/Distributed/Process/Tests/CH.hs
@@ -1421,6 +1421,25 @@ testUnsafeNSend TestTransport{..} = do
 
   takeMVar clientDone
 
+testUnsafeNSendRemote :: TestTransport -> Assertion
+testUnsafeNSendRemote TestTransport{..} = do
+  clientDone <- newEmptyMVar
+
+  localNode1 <- newLocalNode testTransport initRemoteTable
+  localNode2 <- newLocalNode testTransport initRemoteTable
+
+  _ <- forkProcess localNode1 $ do
+    getSelfPid >>= register "foobar"
+    liftIO $ putMVar clientDone ()
+    () <- expect
+    liftIO $ putMVar clientDone ()
+
+  takeMVar clientDone
+  void $ runProcess localNode2 $ do
+    unsafeNSendRemote (localNodeId localNode1) "foobar" ()
+
+  takeMVar clientDone
+
 testUnsafeSendChan :: TestTransport -> Assertion
 testUnsafeSendChan TestTransport{..} = do
   serverAddr <- newEmptyMVar
@@ -1563,6 +1582,7 @@ tests testtrans = return [
       , testCase "TestUnsafeSend"      (testUnsafeSend          testtrans)
       , testCase "TestUnsafeUSend"     (testUnsafeUSend         testtrans)
       , testCase "TestUnsafeNSend"     (testUnsafeNSend         testtrans)
+      , testCase "TestUnsafeNSendRemote" (testUnsafeNSendRemote testtrans)
       , testCase "TestUnsafeSendChan"  (testUnsafeSendChan      testtrans)
       -- usend
       , testCase "USend"               (testUSend usend         testtrans 50)


### PR DESCRIPTION
unsafeNSendRemote and unsafeUSend were submitted in
https://github.com/haskell-distributed/distributed-process/pull/263
